### PR TITLE
Fix `BufferTooSmall`'s `bits_needed` calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,8 +181,8 @@ pub struct BitReader<'a> {
     Buffer is missing {bits_needed} bits"
 )]
 pub struct UnexpectedEndOfBits {
-    n_bits: usize,
-    bits_needed: usize,
+    pub n_bits: usize,
+    pub bits_needed: usize,
 }
 
 macro_rules! read_primitive {
@@ -269,8 +269,8 @@ impl core::fmt::Debug for BitWriter<'_> {
     Buffer needs to be at least {bits_needed} bits extra"
 )]
 pub struct BufferTooSmall {
-    n_bits: usize,
-    bits_needed: usize,
+    pub n_bits: usize,
+    pub bits_needed: usize,
 }
 
 macro_rules! write_primitive {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ macro_rules! write_primitive {
             if self.pos + n_bits > self.buf.len() {
                 Err(BufferTooSmall {
                     n_bits,
-                    bits_needed: self.buf.len() - (self.pos + n_bits),
+                    bits_needed: (self.pos + n_bits) - self.buf.len(),
                 })
             } else {
                 self.buf[self.pos..self.pos + n_bits].copy_from_bitslice(&val[..n_bits]);

--- a/tests/buffer_too_small.rs
+++ b/tests/buffer_too_small.rs
@@ -1,0 +1,25 @@
+use abstract_bits::{AbstractBits, BitWriter};
+
+// Writing past the buffer must report the bit deficit, not underflow computing it.
+
+#[test]
+fn deficit_into_empty_buffer() {
+    let mut buf = [0u8; 1];
+    let mut writer = BitWriter::from(&mut buf[..]);
+
+    let err = 0xABCDu16.write_abstract_bits(&mut writer).unwrap_err();
+    let cause = std::error::Error::source(&err).unwrap();
+    assert!(cause.to_string().contains("8 bits extra"));
+}
+
+#[test]
+fn deficit_accounts_for_position() {
+    let mut buf = [0u8; 2];
+    let mut writer = BitWriter::from(&mut buf[..]);
+
+    0xABu8.write_abstract_bits(&mut writer).unwrap();
+
+    let err = 0xCDEFu16.write_abstract_bits(&mut writer).unwrap_err();
+    let cause = std::error::Error::source(&err).unwrap();
+    assert!(cause.to_string().contains("8 bits extra"));
+}

--- a/tests/buffer_too_small.rs
+++ b/tests/buffer_too_small.rs
@@ -1,6 +1,6 @@
-use abstract_bits::{AbstractBits, BitWriter};
+use abstract_bits::{AbstractBits, BitWriter, BufferTooSmall, ToBytesError};
 
-// Writing past the buffer must report the bit deficit, not underflow computing it.
+// Writing past the buffer must report the bit deficit.
 
 #[test]
 fn deficit_into_empty_buffer() {
@@ -8,8 +8,16 @@ fn deficit_into_empty_buffer() {
     let mut writer = BitWriter::from(&mut buf[..]);
 
     let err = 0xABCDu16.write_abstract_bits(&mut writer).unwrap_err();
-    let cause = std::error::Error::source(&err).unwrap();
-    assert!(cause.to_string().contains("8 bits extra"));
+    assert_eq!(
+        err,
+        ToBytesError::BufferTooSmall {
+            ty: "u16",
+            cause: BufferTooSmall {
+                n_bits: 16,
+                bits_needed: 8,
+            },
+        }
+    );
 }
 
 #[test]
@@ -20,6 +28,14 @@ fn deficit_accounts_for_position() {
     0xABu8.write_abstract_bits(&mut writer).unwrap();
 
     let err = 0xCDEFu16.write_abstract_bits(&mut writer).unwrap_err();
-    let cause = std::error::Error::source(&err).unwrap();
-    assert!(cause.to_string().contains("8 bits extra"));
+    assert_eq!(
+        err,
+        ToBytesError::BufferTooSmall {
+            ty: "u16",
+            cause: BufferTooSmall {
+                n_bits: 16,
+                bits_needed: 8,
+            },
+        }
+    );
 }


### PR DESCRIPTION
Hello! I've picked https://github.com/zigpy/ziggurat/ up again and ran into some minor bugs while fuzzing. The subtraction logic in `BufferTooSmall`'s `bits_needed` field is flipped.

To make testing a bit easier, I've made the `UnexpectedEndOfBits` and `BufferTooSmall` fields public.