### PR TITLE
Support any exported `arbitrary_int` unsigned type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 pub use abstract_bits_derive::abstract_bits;
-pub use arbitrary_int::{u1, u2, u3, u4, u5, u6, u7};
+pub use arbitrary_int::*;
 pub use bitvec;
 use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;

--- a/tests/bitfield.rs
+++ b/tests/bitfield.rs
@@ -8,6 +8,15 @@ struct Register {
     count: u2,
 }
 
+#[derive(Debug, PartialEq)]
+#[abstract_bits]
+struct UnalignedPack {
+    field_a: u27,
+    field_b: u7,
+    field_c: u37,
+    field_d: u9,
+}
+
 // #[abstract_bits]
 // struct NormalStruct {
 //     list: [bool; 5],
@@ -26,4 +35,39 @@ fn main() {
 
     // assert_eq!(NormalStruct::MIN_BITS, NormalStruct::MAX_BITS);
     // assert_eq!(NormalStruct::MIN_BITS, 5);
+}
+
+#[test]
+fn arbitrary_int_packing() {
+    let s = UnalignedPack {
+        field_a: 0b101_11111101_11111111_01111111,
+        field_b: 0b10_10011,
+        field_c: 0b1111011_11011111_11111111_01111111_111011,
+        field_d: 0b10001000_1,
+    };
+
+    let bytes = s.to_abstract_bits().unwrap();
+    assert_eq!(
+        bytes,
+        vec![
+            // field_a
+            0b01111111,
+            0b11111111,
+            0b11111101,
+            // field_a + field_b
+            0b10011_101,
+            // field_b + field_c
+            0b111011_10,
+            // field_c
+            0b01111111,
+            0b11111111,
+            0b11011111,
+            // field_c + field_d
+            0b1_1111011,
+            0b10001000,
+        ]
+    );
+
+    let parsed = StrangeInts::from_abstract_bits(&bytes).unwrap();
+    assert_eq!(parsed, s);
 }


### PR DESCRIPTION
I ran into an edge case where `u24` could not be directly used without [a few hacks](https://github.com/zigpy/ziggurat/blob/f3637f7b1018c255c2724bfece40454f9bfb7a83/crates/ziggurat-zigbee/src/beacon.rs#L8-L35). This PR explicitly adds a test for nonstandard _large_ ints as well.