### PR TITLE
`no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["David Kleingeld"]
 
 [dependencies]
 arbitrary-int = "1.3.0"
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
+bitvec = { version = "1.0.1", default-features = false }
 thiserror = { version = "2.0.12", default-features = false }
 abstract-bits-derive = { path = "abstract-bits-derive", version = "0.2.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ authors = ["David Kleingeld"]
 
 [dependencies]
 arbitrary-int = "1.3.0"
-bitvec = "1.0.1"
-thiserror = "2.0.12"
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
+thiserror = { version = "2.0.12", default-features = false }
 abstract-bits-derive = { path = "abstract-bits-derive", version = "0.2.0" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.86"
 
 readme = "README.md"
 description = "Turn any combination of bit and byte fields into a structs"
-categories = ["data-structures", "no-std::no-alloc", "embedded", "rust-patterns"]
+categories = ["data-structures", "no-std", "embedded", "rust-patterns"]
 repository = "https://github.com/dvdsk/abstract-bits"
 
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 # Planned features
-- `no-std` & `no-alloc` support (quite trivial)
+- `no-alloc` support
 - Support algebraic data-types other than Option (already supported)
 
 # Possible features

--- a/abstract-bits-derive/src/codegen/enumerate.rs
+++ b/abstract-bits-derive/src/codegen/enumerate.rs
@@ -46,9 +46,9 @@ pub fn read(variants: &[EmptyVariant], repr: Ident, bits: usize) -> TokenStream 
         match discriminant {
             #(#variants_discriminants => Ok(Self::#variant_idents)),*,
             invalid => Err(::abstract_bits::FromBytesError::ReadEnum {
-                enum_name: std::any::type_name::<Self>(),
+                enum_name: ::core::any::type_name::<Self>(),
                 cause: ::abstract_bits::ReadErrorCause::InvalidDiscriminant {
-                    ty: std::any::type_name::<Self>(),
+                    ty: ::core::any::type_name::<Self>(),
                     got: discriminant as usize,
                 }
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
 
 pub use abstract_bits_derive::abstract_bits;
 pub use arbitrary_int::*;
@@ -23,7 +28,7 @@ pub trait AbstractBits {
 
     fn to_abstract_bits(&self) -> Result<Vec<u8>, ToBytesError> {
         let needed_bytes = Self::MAX_BITS.div_ceil(8);
-        let mut buffer = vec![0u8; needed_bytes];
+        let mut buffer = alloc::vec![0u8; needed_bytes];
         let mut writer = BitWriter::from(buffer.as_mut_slice());
         self.write_abstract_bits(&mut writer)?;
         let bytes = writer.bytes_written();
@@ -53,7 +58,7 @@ macro_rules! impl_abstract_bits_for_UInt {
                 writer
                     .$write_method(Self::BITS, self.value())
                     .map_err(|cause| ToBytesError::BufferTooSmall {
-                        ty: std::any::type_name::<Self>(),
+                        ty: core::any::type_name::<Self>(),
                         cause,
                     })
             }
@@ -65,7 +70,7 @@ macro_rules! impl_abstract_bits_for_UInt {
                 use FromBytesError::ReadPrimitive;
                 let value = reader.$read_method(Self::BITS).map_err(|cause| {
                     ReadPrimitive(ReadErrorCause::NotEnoughInput {
-                        ty: std::any::type_name::<Self>(),
+                        ty: core::any::type_name::<Self>(),
                         cause,
                     })
                 })?;
@@ -92,7 +97,7 @@ macro_rules! impl_abstract_bits_for_core_int {
             ) -> Result<(), ToBytesError> {
                 writer.$write_method($bits, *self).map_err(|cause| {
                     ToBytesError::BufferTooSmall {
-                        ty: std::any::type_name::<Self>(),
+                        ty: core::any::type_name::<Self>(),
                         cause,
                     }
                 })
@@ -105,7 +110,7 @@ macro_rules! impl_abstract_bits_for_core_int {
                 use FromBytesError::ReadPrimitive;
                 reader.$read_method($bits).map_err(|cause| {
                     ReadPrimitive(ReadErrorCause::NotEnoughInput {
-                        ty: std::any::type_name::<Self>(),
+                        ty: core::any::type_name::<Self>(),
                         cause,
                     })
                 })
@@ -256,7 +261,7 @@ pub struct BitWriter<'a> {
 }
 
 impl core::fmt::Debug for BitWriter<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("BitWriter\n")?;
         f.write_fmt(format_args!("\tpos: {}\n", self.pos))?;
         f.write_fmt(format_args!("\tbuf: BitSlice of {} bits\n", self.buf.len()))

--- a/tests/bitfield.rs
+++ b/tests/bitfield.rs
@@ -68,6 +68,6 @@ fn arbitrary_int_packing() {
         ]
     );
 
-    let parsed = StrangeInts::from_abstract_bits(&bytes).unwrap();
+    let parsed = UnalignedPack::from_abstract_bits(&bytes).unwrap();
     assert_eq!(parsed, s);
 }


### PR DESCRIPTION
This tiny PR allows abstract-bits and abstract-bits-derive to be built in a no-std environment.