### PR TITLE
Rename `abstract_bits` functions to `abstract_bytes` and add new `_bits` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["David Kleingeld"]
 
 [dependencies]
 arbitrary-int = "1.3.0"
-bitvec = { version = "1.0.1", default-features = false }
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 thiserror = { version = "2.0.12", default-features = false }
 abstract-bits-derive = { path = "abstract-bits-derive", version = "0.2.0" }
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         is_first_frame: false,
         is_last_frame: true,
         link_statuses: Vec::new(),
-    }.to_abstract_bits()?;
-    let link_status_cmd = LinkStatusCommand::from_abstract_bits(&bytes)?;
+    }.to_abstract_bytes()?;
+    let link_status_cmd = LinkStatusCommand::from_abstract_bytes(&bytes)?;
     print!("number of links: {}", link_status_cmd.link_statuses.len());
     Ok(())
 }
@@ -126,7 +126,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             is_important: false,
             bits: [true, false, true, true, true, false, true, true, false, true]
         }],
-    }.to_abstract_bits()?;
+    }.to_abstract_bytes()?;
     let mut reader = BitReader::from(bytes.as_slice());
     let mut frame = Frame::read_abstract_bits(&mut reader)?;
     if frame.frame_type == Type::default() {
@@ -134,7 +134,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             message.is_important = true;
         }
     }
-    let bytes = frame.to_abstract_bits();
+    let bytes = frame.to_abstract_bytes();
     Ok(())
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use arbitrary_int::*;
 pub use bitvec;
 use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;
+use bitvec::vec::BitVec;
 
 mod error;
 pub use error::{FromBytesError, ReadErrorCause, ToBytesError};
@@ -26,22 +27,41 @@ pub trait AbstractBits {
     where
         Self: Sized;
 
-    fn to_abstract_bytes(&self) -> Result<Vec<u8>, ToBytesError> {
+    /// Serialize to an exactly-sized bit buffer. Lossless for every type,
+    /// including those whose length is not a multiple of 8 bits. Use
+    /// [`to_abstract_bytes`](AbstractBits::to_abstract_bytes) for byte output.
+    fn to_abstract_bits(&self) -> Result<BitVec<u8, Lsb0>, ToBytesError> {
         let needed_bytes = Self::MAX_BITS.div_ceil(8);
         let mut buffer = alloc::vec![0u8; needed_bytes];
         let mut writer = BitWriter::from(buffer.as_mut_slice());
         self.write_abstract_bits(&mut writer)?;
-        let bytes = writer.bytes_written();
-        buffer.truncate(bytes);
+        let bits = writer.bits_written();
+        let mut buffer = BitVec::<u8, Lsb0>::from_vec(buffer);
+        buffer.truncate(bits);
         Ok(buffer)
     }
 
+    /// Deserialize from a bit buffer as produced by
+    /// [`to_abstract_bits`](AbstractBits::to_abstract_bits).
+    fn from_abstract_bits(bits: &BitSlice<u8, Lsb0>) -> Result<Self, FromBytesError>
+    where
+        Self: Sized,
+    {
+        let mut reader = BitReader::from(bits);
+        Self::read_abstract_bits(&mut reader)
+    }
+
+    /// Serialize to bytes, zero-padding the final byte up to a whole byte if needed.
+    fn to_abstract_bytes(&self) -> Result<Vec<u8>, ToBytesError> {
+        Ok(self.to_abstract_bits()?.into_vec())
+    }
+
+    /// Deserialize from a byte slice.
     fn from_abstract_bytes(bytes: &[u8]) -> Result<Self, FromBytesError>
     where
         Self: Sized,
     {
-        let mut reader = BitReader::from(bytes);
-        Self::read_abstract_bits(&mut reader)
+        Self::from_abstract_bits(BitSlice::from_slice(bytes))
     }
 }
 
@@ -252,6 +272,12 @@ impl<'a> From<&'a [u8]> for BitReader<'a> {
             pos: 0,
             buf: BitSlice::from_slice(bytes),
         }
+    }
+}
+
+impl<'a> From<&'a BitSlice<u8, Lsb0>> for BitReader<'a> {
+    fn from(buf: &'a BitSlice<u8, Lsb0>) -> Self {
+        Self { pos: 0, buf }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub trait AbstractBits {
     where
         Self: Sized;
 
-    fn to_abstract_bits(&self) -> Result<Vec<u8>, ToBytesError> {
+    fn to_abstract_bytes(&self) -> Result<Vec<u8>, ToBytesError> {
         let needed_bytes = Self::MAX_BITS.div_ceil(8);
         let mut buffer = alloc::vec![0u8; needed_bytes];
         let mut writer = BitWriter::from(buffer.as_mut_slice());
@@ -36,7 +36,7 @@ pub trait AbstractBits {
         Ok(buffer)
     }
 
-    fn from_abstract_bits(bytes: &[u8]) -> Result<Self, FromBytesError>
+    fn from_abstract_bytes(bytes: &[u8]) -> Result<Self, FromBytesError>
     where
         Self: Sized,
     {

--- a/tests/bit_and_byte_api.rs
+++ b/tests/bit_and_byte_api.rs
@@ -1,0 +1,38 @@
+//! Tests for the bits and bytes APIs.
+use abstract_bits::{AbstractBits, abstract_bits};
+
+#[abstract_bits]
+#[derive(Debug, PartialEq)]
+struct SubByte {
+    head: u8,
+    tail: u3, // total = 11 bits, not a multiple of 8
+}
+
+#[test]
+fn bits_buffer_has_exact_length() {
+    let bits = SubByte { head: 0xAB, tail: 5 }.to_abstract_bits().unwrap();
+    assert_eq!(bits.len(), 11);
+    assert_eq!(bits.len(), SubByte::MAX_BITS);
+}
+
+#[test]
+fn roundtrips_through_bits() {
+    let value = SubByte { head: 0xAB, tail: 5 };
+    let bits = value.to_abstract_bits().unwrap();
+    assert_eq!(SubByte::from_abstract_bits(&bits).unwrap(), value);
+}
+
+#[test]
+fn roundtrips_through_bytes_with_tail_padding() {
+    let value = SubByte { head: 0xAB, tail: 5 };
+    let bytes = value.to_abstract_bytes().unwrap();
+    assert_eq!(bytes.len(), 2); // 11 bits padded up to 2 whole bytes
+    assert_eq!(SubByte::from_abstract_bytes(&bytes).unwrap(), value);
+}
+
+#[test]
+fn bytes_are_the_bit_buffer_padded_to_a_byte() {
+    let value = SubByte { head: 0xAB, tail: 5 };
+    let bits = value.to_abstract_bits().unwrap();
+    assert_eq!(value.to_abstract_bytes().unwrap(), bits.into_vec());
+}

--- a/tests/bitfield.rs
+++ b/tests/bitfield.rs
@@ -46,7 +46,7 @@ fn arbitrary_int_packing() {
         field_d: 0b10001000_1,
     };
 
-    let bytes = s.to_abstract_bits().unwrap();
+    let bytes = s.to_abstract_bytes().unwrap();
     assert_eq!(
         bytes,
         vec![
@@ -68,6 +68,6 @@ fn arbitrary_int_packing() {
         ]
     );
 
-    let parsed = UnalignedPack::from_abstract_bits(&bytes).unwrap();
+    let parsed = UnalignedPack::from_abstract_bytes(&bytes).unwrap();
     assert_eq!(parsed, s);
 }

--- a/tests/complex_controllers.rs
+++ b/tests/complex_controllers.rs
@@ -17,8 +17,8 @@ fn inverted_presence_present() {
         opt: Some(0x1234),
         trailing: 0x5A,
     };
-    let bytes = value.to_abstract_bits().unwrap();
-    assert_eq!(Inverted::from_abstract_bits(&bytes).unwrap(), value);
+    let bytes = value.to_abstract_bytes().unwrap();
+    assert_eq!(Inverted::from_abstract_bytes(&bytes).unwrap(), value);
 }
 
 #[test]
@@ -28,8 +28,8 @@ fn inverted_presence_absent() {
         opt: None,
         trailing: 0x5A,
     };
-    let bytes = value.to_abstract_bits().unwrap();
-    assert_eq!(Inverted::from_abstract_bits(&bytes).unwrap(), value);
+    let bytes = value.to_abstract_bytes().unwrap();
+    assert_eq!(Inverted::from_abstract_bytes(&bytes).unwrap(), value);
 }
 
 // One controller driving several options. `present` is a bare same-struct field, so it
@@ -53,8 +53,8 @@ fn shared_presence_present() {
         b: Some(0x2222),
         trailing: 0x5A,
     };
-    let bytes = value.to_abstract_bits().unwrap();
-    assert_eq!(SharedPresence::from_abstract_bits(&bytes).unwrap(), value);
+    let bytes = value.to_abstract_bytes().unwrap();
+    assert_eq!(SharedPresence::from_abstract_bytes(&bytes).unwrap(), value);
 }
 
 #[test]
@@ -64,6 +64,6 @@ fn shared_presence_absent() {
         b: None,
         trailing: 0x5A,
     };
-    let bytes = value.to_abstract_bits().unwrap();
-    assert_eq!(SharedPresence::from_abstract_bits(&bytes).unwrap(), value);
+    let bytes = value.to_abstract_bytes().unwrap();
+    assert_eq!(SharedPresence::from_abstract_bytes(&bytes).unwrap(), value);
 }

--- a/tests/end_on_empty_vec.rs
+++ b/tests/end_on_empty_vec.rs
@@ -17,8 +17,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         is_last_frame: true,
         link_statuses: Vec::new(),
     }
-    .to_abstract_bits()?;
-    let link_status_cmd = LinkStatusCommand::from_abstract_bits(&bytes)?;
+    .to_abstract_bytes()?;
+    let link_status_cmd = LinkStatusCommand::from_abstract_bytes(&bytes)?;
     assert_eq!(link_status_cmd.link_statuses.len(), 0);
     print!("number of links: {}", link_status_cmd.link_statuses.len());
     Ok(())

--- a/tests/enum_variant_presence.rs
+++ b/tests/enum_variant_presence.rs
@@ -35,7 +35,7 @@ fn enum_variant_gates_presence() {
             trailing: 34,
         },
     ] {
-        let bytes = frame.to_abstract_bits().unwrap();
-        assert_eq!(Frame::from_abstract_bits(&bytes).unwrap(), frame);
+        let bytes = frame.to_abstract_bytes().unwrap();
+        assert_eq!(Frame::from_abstract_bytes(&bytes).unwrap(), frame);
     }
 }

--- a/tests/from_ziggurat.rs
+++ b/tests/from_ziggurat.rs
@@ -54,7 +54,7 @@ fn test_nwk_route_reply_command() {
 
     dbg!(NwkRouteReplyCommand::MAX_BITS);
     dbg!(bytes.len());
-    let command = NwkRouteReplyCommand::from_abstract_bits(&bytes).unwrap();
+    let command = NwkRouteReplyCommand::from_abstract_bytes(&bytes).unwrap();
 
     assert_eq!(
         command,
@@ -68,7 +68,7 @@ fn test_nwk_route_reply_command() {
         }
     );
 
-    assert_eq!(command.to_abstract_bits().unwrap(), &bytes);
+    assert_eq!(command.to_abstract_bytes().unwrap(), &bytes);
 }
 
 /// Zigbee spec compressed: 3.4.8.3
@@ -98,7 +98,7 @@ pub struct NwkLinkStatus {
 fn test_nwk_link_status_command() {
     use hex_literal::hex;
     let bytes = hex!("0862e73c120ac711").to_vec();
-    let command = NwkLinkStatusCommand::from_abstract_bits(&bytes[1..]).unwrap();
+    let command = NwkLinkStatusCommand::from_abstract_bytes(&bytes[1..]).unwrap();
 
     assert_eq!(
         command,
@@ -120,7 +120,7 @@ fn test_nwk_link_status_command() {
         }
     );
 
-    assert_eq!(&command.to_abstract_bits().unwrap(), &bytes[1..]);
+    assert_eq!(&command.to_abstract_bytes().unwrap(), &bytes[1..]);
 }
 
 #[abstract_bits(bits = 2)]
@@ -189,7 +189,7 @@ pub struct NwkHeader {
 fn test_nested_nwk_header() {
     use hex_literal::hex;
     let bytes = hex!("0806e73c375f1dcc010039f9").to_vec();
-    let header = NwkHeader::from_abstract_bits(&bytes).unwrap();
+    let header = NwkHeader::from_abstract_bytes(&bytes).unwrap();
 
     assert_eq!(
         header,
@@ -219,5 +219,5 @@ fn test_nested_nwk_header() {
         }
     );
 
-    assert_eq!(&header.to_abstract_bits().unwrap(), &bytes);
+    assert_eq!(&header.to_abstract_bytes().unwrap(), &bytes);
 }

--- a/tests/fuzz_case1.rs
+++ b/tests/fuzz_case1.rs
@@ -37,8 +37,8 @@ enum Type {
 fn test_test_case() {
     color_eyre::install().unwrap();
 
-    let serialized = test_input().to_abstract_bits().unwrap();
-    let deserialized = Frame::from_abstract_bits(&serialized).unwrap();
+    let serialized = test_input().to_abstract_bytes().unwrap();
+    let deserialized = Frame::from_abstract_bytes(&serialized).unwrap();
     assert_eq!(test_input(), deserialized)
 }
 


### PR DESCRIPTION
This PR makes the `_bits` methods true to their name: functions that operate on `BitVec`. The existing APIs have been renamed to `_bytes`.

I'm working on finishing up the `rest` feature for absorbing trailing bytes/bytes. This API switch ensures that non-integer alignment doesn't cause any issues (i.e. `rest: Vec<u7>` followed by `padding: u2` can round-trip instead of being ambiguous due to being padded up to 8 bits).