### PR TITLE
Support trailing element fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - For each `Vec` field add `#[abstract_bits(length_from = <controller_field>)]`
   above the field, where `<controller_field>` is a numeric field that controls
   the length of the `Vec`.
+- For a `Vec` field that should be read until the input (or the enclosing TLV
+  value) is exhausted rather than from a length prefix, use
+  `#[abstract_bits(rest, max_bytes = <N>)]`. `<N>` bounds the serialized size in
+  bytes, which such an otherwise-unbounded field needs.
 
 ## With an enum
 - Add `#[abstract-bits(bits = <N>)]` above your enum. Replace `N` with the
@@ -94,16 +98,18 @@ struct Frame {
     source: Option<u16>,
     #[abstract_bits(length_from = data_len)]
     data: Vec<Message>,
+    #[abstract_bits(rest, max_bytes = 64)]
+    trailing_data: Vec<u8>,
 }
 
-/// This is: 4+3+1+10 = 18 bits long
+/// This is: 4+3+1+12 = 20 bits long
 #[abstract_bits]
 #[derive(Debug, PartialEq, Eq)]
 struct Message {
     header: u4,
     reserved: u3,
     is_important: bool,
-    bits: [bool; 10]
+    bits: [bool; 12]
 }
 
 #[abstract_bits(bits = 2)]
@@ -121,11 +127,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         header: 12,
         frame_type: Type::default(),
         source: Some(4243),
-        data: vec![Message {
-            header: 9,
-            is_important: false,
-            bits: [true, false, true, true, true, false, true, true, false, true]
-        }],
+        data: vec![
+            Message {
+                header: 9,
+                is_important: false,
+                bits: [1, 0, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1].map(|b| b == 1)
+            },
+            Message {
+                header: 6,
+                is_important: false,
+                bits: [0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0].map(|b| b == 1)
+            },
+        ],
+        trailing_data: vec![1, 2, 3, 4, 5],
     }.to_abstract_bytes()?;
     let mut reader = BitReader::from(bytes.as_slice());
     let mut frame = Frame::read_abstract_bits(&mut reader)?;

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   the length of the `Vec`.
 - For a `Vec` field that should be read until the input (or the enclosing TLV
   value) is exhausted rather than from a length prefix, use
-  `#[abstract_bits(rest, max_bytes = <N>)]`. `<N>` bounds the serialized size in
-  bytes, which such an otherwise-unbounded field needs.
+  `#[abstract_bits(rest, max_bits = <N>)]`. `<N>` bounds the serialized size in
+  bits, which such an otherwise-unbounded field needs.
 
 ## With an enum
 - Add `#[abstract-bits(bits = <N>)]` above your enum. Replace `N` with the
@@ -98,7 +98,7 @@ struct Frame {
     source: Option<u16>,
     #[abstract_bits(length_from = data_len)]
     data: Vec<Message>,
-    #[abstract_bits(rest, max_bytes = 64)]
+    #[abstract_bits(rest, max_bits = 512)]
     trailing_data: Vec<u8>,
 }
 

--- a/abstract-bits-derive/src/codegen.rs
+++ b/abstract-bits-derive/src/codegen.rs
@@ -177,7 +177,10 @@ impl ToTokens for super::model::EmptyVariant {
 }
 
 /// Path to abstract-bits' re-exported `uN` arbitrary-int type, e.g. `::abstract_bits::u7`.
-pub fn arbitrary_uint(bits: impl std::fmt::Display, span: proc_macro2::Span) -> syn::Type {
+pub fn arbitrary_uint(
+    bits: impl std::fmt::Display,
+    span: proc_macro2::Span,
+) -> syn::Type {
     let ident = Ident::new(&format!("u{bits}"), span);
     syn::parse_quote_spanned!(span=> ::abstract_bits::#ident)
 }

--- a/abstract-bits-derive/src/codegen.rs
+++ b/abstract-bits-derive/src/codegen.rs
@@ -176,6 +176,12 @@ impl ToTokens for super::model::EmptyVariant {
     }
 }
 
+/// Path to abstract-bits' re-exported `uN` arbitrary-int type, e.g. `::abstract_bits::u7`.
+pub fn arbitrary_uint(bits: impl std::fmt::Display, span: proc_macro2::Span) -> syn::Type {
+    let ident = Ident::new(&format!("u{bits}"), span);
+    syn::parse_quote_spanned!(span=> ::abstract_bits::#ident)
+}
+
 pub fn is_primitive(bits: usize) -> Option<TokenStream> {
     match bits {
         8 => Some(quote! {u8}),

--- a/abstract-bits-derive/src/codegen.rs
+++ b/abstract-bits-derive/src/codegen.rs
@@ -102,10 +102,18 @@ fn normal_struct(
         .iter()
         .filter_map(Field::needed_in_struct_def)
         .collect();
-    let write_code: Vec<_> = fields.iter().map(|f| f.write_code(&ident)).collect();
-    let read_code: Vec<_> = fields.iter().map(|f| f.read_code(&ident)).collect();
+
     let min_bits_code: Vec<_> = fields.iter().map(Field::min_bits_code).collect();
     let max_bits_code: Vec<_> = fields.iter().map(Field::max_bits_code).collect();
+
+    let write_code: Vec<_> = fields.iter().map(|f| f.write_code(&ident)).collect();
+    let read_code: Vec<_> = fields
+        .iter()
+        .enumerate()
+        // Provide context about trailing fields so we can reserve space for them
+        .map(|(i, f)| f.read_code(&ident, &min_bits_code[i + 1..].iter().as_slice()))
+        .collect();
+
     let out_struct_idents: Vec<_> = fields
         .iter()
         .filter_map(Field::needed_in_struct_def)

--- a/abstract-bits-derive/src/codegen.rs
+++ b/abstract-bits-derive/src/codegen.rs
@@ -111,7 +111,9 @@ fn normal_struct(
         .iter()
         .enumerate()
         // Provide context about trailing fields so we can reserve space for them
-        .map(|(i, f)| f.read_code(&ident, &min_bits_code[i + 1..]))
+        .map(|(i, f)| {
+            f.read_code(&ident, &min_bits_code[i + 1..], &max_bits_code[i + 1..])
+        })
         .collect();
 
     let out_struct_idents: Vec<_> = fields

--- a/abstract-bits-derive/src/codegen.rs
+++ b/abstract-bits-derive/src/codegen.rs
@@ -111,7 +111,7 @@ fn normal_struct(
         .iter()
         .enumerate()
         // Provide context about trailing fields so we can reserve space for them
-        .map(|(i, f)| f.read_code(&ident, &min_bits_code[i + 1..].iter().as_slice()))
+        .map(|(i, f)| f.read_code(&ident, &min_bits_code[i + 1..]))
         .collect();
 
     let out_struct_idents: Vec<_> = fields

--- a/abstract-bits-derive/src/codegen/enumerate.rs
+++ b/abstract-bits-derive/src/codegen/enumerate.rs
@@ -4,7 +4,7 @@ use syn::Ident;
 
 use crate::model::EmptyVariant;
 
-use super::is_primitive;
+use super::{arbitrary_uint, is_primitive};
 
 pub(crate) fn write(repr: Ident, bits: usize) -> TokenStream {
     if is_primitive(bits).is_some() {
@@ -12,8 +12,7 @@ pub(crate) fn write(repr: Ident, bits: usize) -> TokenStream {
             ::abstract_bits::AbstractBits::write_abstract_bits(&(*self as #repr), writer)
         }
     } else {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("valid type path");
+        let utype = arbitrary_uint(bits, repr.span());
         quote_spanned! {repr.span()=>
             let discriminant = #utype::new(*self as #repr);
             ::abstract_bits::AbstractBits::write_abstract_bits(&discriminant, writer)
@@ -33,8 +32,7 @@ pub fn read(variants: &[EmptyVariant], repr: Ident, bits: usize) -> TokenStream 
             let discriminant = #repr::read_abstract_bits(reader)?;
         }
     } else {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("valid type path");
+        let utype = arbitrary_uint(bits, repr.span());
         quote_spanned! {repr.span()=>
             let discriminant = #utype::read_abstract_bits(reader)?;
             let discriminant = discriminant.value();

--- a/abstract-bits-derive/src/codegen/fields.rs
+++ b/abstract-bits-derive/src/codegen/fields.rs
@@ -14,6 +14,7 @@ impl Field {
         &self,
         struct_ident: &syn::Ident,
         following_min_bits: &[TokenStream],
+        following_max_bits: &[TokenStream],
     ) -> TokenStream {
         let struct_name = proc_macro2::Literal::string(&struct_ident.to_string());
         match self {
@@ -33,7 +34,13 @@ impl Field {
                 inner_type,
                 max_bits,
                 ..
-            } => rest_list::read(inner_type, &struct_name, *max_bits, following_min_bits),
+            } => rest_list::read(
+                inner_type,
+                &struct_name,
+                *max_bits,
+                following_min_bits,
+                following_max_bits,
+            ),
             Field::HiddenController { field, .. } => normal::read(field, &struct_name),
             Field::Array {
                 length,

--- a/abstract-bits-derive/src/codegen/fields.rs
+++ b/abstract-bits-derive/src/codegen/fields.rs
@@ -7,6 +7,7 @@ mod list;
 mod normal;
 mod option;
 mod padding;
+mod rest_list;
 
 impl Field {
     pub fn read_code(&self, struct_ident: &syn::Ident) -> TokenStream {
@@ -24,6 +25,9 @@ impl Field {
                 controller,
                 ..
             } => list::read(inner_type, controller, &struct_name),
+            Field::RestList { inner_type, .. } => {
+                rest_list::read(inner_type, &struct_name)
+            }
             Field::HiddenController { field, .. } => normal::read(field, &struct_name),
             Field::Array {
                 length,
@@ -40,6 +44,7 @@ impl Field {
             Field::PaddBits(n_bits) => padding::write(*n_bits, &struct_name),
             Field::Option { inner_type, .. } => option::write(inner_type),
             Field::List { inner_type, .. } => list::write(inner_type),
+            Field::RestList { inner_type, .. } => rest_list::write(inner_type),
             Field::HiddenController {
                 field,
                 controlled,
@@ -55,6 +60,7 @@ impl Field {
             Field::PaddBits(n_bits) => padding::min_bits(*n_bits),
             Field::Option { inner_type, .. } => option::min_bits(inner_type),
             Field::List { inner_type, .. } => list::min_bits(inner_type),
+            Field::RestList { .. } => rest_list::min_bits(),
             Field::HiddenController { field, .. } => normal::min_bits(field),
             Field::Array {
                 inner_type, length, ..
@@ -72,6 +78,7 @@ impl Field {
                 max_len,
                 ..
             } => list::max_bits(inner_type, *max_len),
+            Field::RestList { max_bytes, .. } => rest_list::max_bits(*max_bytes),
             Field::HiddenController { field, .. } => normal::max_bits(field),
             Field::Array {
                 inner_type, length, ..

--- a/abstract-bits-derive/src/codegen/fields.rs
+++ b/abstract-bits-derive/src/codegen/fields.rs
@@ -10,7 +10,11 @@ mod padding;
 mod rest_list;
 
 impl Field {
-    pub fn read_code(&self, struct_ident: &syn::Ident) -> TokenStream {
+    pub fn read_code(
+        &self,
+        struct_ident: &syn::Ident,
+        following_min_bits: &[TokenStream],
+    ) -> TokenStream {
         let struct_name = proc_macro2::Literal::string(&struct_ident.to_string());
         match self {
             Field::Normal(normal_field) => normal::read(normal_field, &struct_name),
@@ -25,9 +29,11 @@ impl Field {
                 controller,
                 ..
             } => list::read(inner_type, controller, &struct_name),
-            Field::RestList { inner_type, .. } => {
-                rest_list::read(inner_type, &struct_name)
-            }
+            Field::RestList {
+                inner_type,
+                max_bits,
+                ..
+            } => rest_list::read(inner_type, &struct_name, *max_bits, following_min_bits),
             Field::HiddenController { field, .. } => normal::read(field, &struct_name),
             Field::Array {
                 length,
@@ -78,7 +84,7 @@ impl Field {
                 max_len,
                 ..
             } => list::max_bits(inner_type, *max_len),
-            Field::RestList { max_bytes, .. } => rest_list::max_bits(*max_bytes),
+            Field::RestList { max_bits, .. } => rest_list::max_bits(*max_bits),
             Field::HiddenController { field, .. } => normal::max_bits(field),
             Field::Array {
                 inner_type, length, ..

--- a/abstract-bits-derive/src/codegen/fields/control_list.rs
+++ b/abstract-bits-derive/src/codegen/fields/control_list.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Literal, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::Ident;
 
-use crate::codegen::{is_primitive, list_len_ident};
+use crate::codegen::{arbitrary_uint, is_primitive, list_len_ident};
 
 pub fn read(controlled: &Ident, bits: usize, struct_name: &Literal) -> TokenStream {
     let list_name = Literal::string(&controlled.to_string());
@@ -13,8 +13,7 @@ pub fn read(controlled: &Ident, bits: usize, struct_name: &Literal) -> TokenStre
                 .map_err(|cause| cause.read_list_length(#struct_name, #list_name))?;
         }
     } else {
-        let utype: syn::Type =
-            syn::parse_str(&format!("::abstract_bits::u{bits}")).expect("valid type path");
+        let utype = arbitrary_uint(bits, controlled.span());
         quote_spanned! {controlled.span()=>
             let #len_ident = #utype::read_abstract_bits(reader)
                 .map_err(|cause| cause.read_list_length(#struct_name, #list_name))?;
@@ -35,8 +34,7 @@ pub fn write(controlled: &Ident, bits: usize) -> TokenStream {
             ::abstract_bits::AbstractBits::write_abstract_bits(&#len_ident, writer)?;
         }
     } else {
-        let utype: syn::Type =
-            syn::parse_str(&format!("::abstract_bits::u{bits}")).expect("valid type path");
+        let utype = arbitrary_uint(bits, controlled.span());
         quote_spanned! {controlled.span()=>
             let #len_ident = self.#controlled.len().try_into()
                 .map_err(|_| ::abstract_bits::ToBytesError::ListTooLong {

--- a/abstract-bits-derive/src/codegen/fields/hidden_controller.rs
+++ b/abstract-bits-derive/src/codegen/fields/hidden_controller.rs
@@ -2,6 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote_spanned;
 use syn::Ident;
 
+use crate::codegen::arbitrary_uint;
 use crate::model::NormalField;
 
 /// Derive the controller's value from the field it controls and write it: an
@@ -16,8 +17,7 @@ pub fn write(field: &NormalField, controlled: &Ident, presence: bool) -> TokenSt
     }
 
     if let Some(bits) = field.bits {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("should be valid type path");
+        let utype = arbitrary_uint(bits, ident.span());
         quote_spanned! {ident.span()=>
             let len: #utype = self.#controlled.len().try_into().ok()
                 .and_then(|len| #utype::try_new(len).ok())

--- a/abstract-bits-derive/src/codegen/fields/normal.rs
+++ b/abstract-bits-derive/src/codegen/fields/normal.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, quote_spanned};
 use syn::spanned::Spanned;
 
-use crate::codegen::generics_to_fully_qualified;
+use crate::codegen::{arbitrary_uint, generics_to_fully_qualified};
 use crate::model::NormalField;
 
 pub fn read(
@@ -17,8 +17,7 @@ pub fn read(
 ) -> TokenStream {
     let field_name = proc_macro2::Literal::string(&ident.to_string());
     if let Some(bits) = bits {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("should be valid type path");
+        let utype = arbitrary_uint(bits, out_ty.span());
         quote_spanned! {out_ty.span()=>
             let #ident = #utype::read_abstract_bits(reader)
                 .map_err(|cause| cause.read_field(#struct_name, #field_name))?;
@@ -42,8 +41,7 @@ pub fn write(
     }: &NormalField,
 ) -> TokenStream {
     if let Some(bits) = *bits {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("should be valid type path");
+        let utype = arbitrary_uint(bits, out_ty.span());
         quote_spanned! {out_ty.span()=>
             let #ident = #utype::new(self.#ident);
             #ident.write_abstract_bits(writer)?;

--- a/abstract-bits-derive/src/codegen/fields/option.rs
+++ b/abstract-bits-derive/src/codegen/fields/option.rs
@@ -72,9 +72,8 @@ pub fn write(field: &NormalField) -> TokenStream {
 }
 
 pub(crate) fn min_bits(inner_type: &NormalField) -> TokenStream {
-    let ty = &inner_type.out_ty;
     quote_spanned! {inner_type.ident.span()=>
-        #ty::MIN_BITS
+        0
     }
 }
 

--- a/abstract-bits-derive/src/codegen/fields/option.rs
+++ b/abstract-bits-derive/src/codegen/fields/option.rs
@@ -3,7 +3,7 @@ use quote::quote_spanned;
 use syn::Expr;
 use syn::spanned::Spanned;
 
-use crate::codegen::generics_to_fully_qualified;
+use crate::codegen::{arbitrary_uint, generics_to_fully_qualified};
 use crate::model::NormalField;
 
 pub fn read_field_code(
@@ -17,8 +17,7 @@ pub fn read_field_code(
 ) -> TokenStream {
     let field_name = proc_macro2::Literal::string(&ident.to_string());
     if let Some(bits) = bits {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("should be valid type path");
+        let utype = arbitrary_uint(bits, out_ty.span());
         quote_spanned! {out_ty.span()=>
             let #ident = #utype::read_abstract_bits(reader)
                 .map_err(|cause| cause.read_option(#struct_name, #field_name))?;
@@ -54,8 +53,7 @@ pub fn read(
 pub fn write(field: &NormalField) -> TokenStream {
     let field_ident = &field.ident;
     let write_code = if let Some(bits) = field.bits {
-        let utype: syn::Type = syn::parse_str(&format!("::abstract_bits::u{bits}"))
-            .expect("should be valid type path");
+        let utype = arbitrary_uint(bits, field.out_ty.span());
         quote_spanned! {field.out_ty.span()=>
             let #field_ident = #utype::new(#field_ident);
             #field_ident.write_abstract_bits(writer)?;

--- a/abstract-bits-derive/src/codegen/fields/rest_list.rs
+++ b/abstract-bits-derive/src/codegen/fields/rest_list.rs
@@ -1,0 +1,39 @@
+use proc_macro2::{Literal, TokenStream};
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+
+use crate::codegen::generics_to_fully_qualified;
+use crate::model::NormalField;
+
+pub(crate) fn write(inner_type: &NormalField) -> TokenStream {
+    let field_ident = &inner_type.ident;
+    quote_spanned! {field_ident.span()=>
+        for element in &self.#field_ident {
+            ::abstract_bits::AbstractBits::write_abstract_bits(element, writer)?;
+        }
+    }
+}
+
+pub(crate) fn read(inner_type: &NormalField, struct_name: &Literal) -> TokenStream {
+    let field_name = Literal::string(&inner_type.ident.to_string());
+    let field_ident = &inner_type.ident;
+    let inner_ty = generics_to_fully_qualified(inner_type.out_ty.clone());
+    quote_spanned! {inner_ty.span()=>
+        let mut #field_ident = ::std::vec::Vec::new();
+        while reader.remaining_bits() > 0 {
+            let element =
+                <#inner_ty as ::abstract_bits::AbstractBits>::read_abstract_bits(reader)
+                    .map_err(|cause| cause.read_field(#struct_name, #field_name))?;
+            #field_ident.push(element);
+        }
+    }
+}
+
+pub(crate) fn min_bits() -> TokenStream {
+    quote! { 0 }
+}
+
+pub(crate) fn max_bits(max_bytes: usize) -> TokenStream {
+    let bits = Literal::usize_unsuffixed(max_bytes * 8);
+    quote! { #bits }
+}

--- a/abstract-bits-derive/src/codegen/fields/rest_list.rs
+++ b/abstract-bits-derive/src/codegen/fields/rest_list.rs
@@ -23,9 +23,18 @@ pub(crate) fn write(inner_type: &NormalField) -> TokenStream {
     }
 }
 
-pub(crate) fn read(inner_type: &NormalField, struct_name: &Literal) -> TokenStream {
+pub(crate) fn read(
+    inner_type: &NormalField,
+    struct_name: &Literal,
+    max_bits: usize,
+    following_min_bits: &[TokenStream],
+) -> TokenStream {
     let field_name = Literal::string(&inner_type.ident.to_string());
     let field_ident = &inner_type.ident;
+    let window = Literal::usize_unsuffixed(max_bits);
+
+    // Bits the fields after us still need
+    let reserved_bits = quote! { 0 #(+ (#following_min_bits))* };
 
     // Arbitrary integer fields are stored in a vec of _primitive_ integers
     if let Some(bits) = inner_type.bits {
@@ -34,7 +43,10 @@ pub(crate) fn read(inner_type: &NormalField, struct_name: &Literal) -> TokenStre
 
         quote_spanned! {field_ident.span()=>
             let mut #field_ident = ::std::vec::Vec::new();
-            while reader.remaining_bits() >= #element_bits && reader.bits_read() < Self::MAX_BITS {
+            let rest_start = reader.bits_read();
+            while reader.remaining_bits() >= #element_bits + (#reserved_bits)
+                && (reader.bits_read() - rest_start) + #element_bits <= #window
+            {
                 let element = #utype::read_abstract_bits(reader)
                     .map_err(|cause| cause.read_field(#struct_name, #field_name))?
                     .value();
@@ -46,8 +58,13 @@ pub(crate) fn read(inner_type: &NormalField, struct_name: &Literal) -> TokenStre
 
         quote_spanned! {inner_ty.span()=>
             let mut #field_ident = ::std::vec::Vec::new();
-            while reader.remaining_bits() >= <#inner_ty as ::abstract_bits::AbstractBits>::MIN_BITS
-                && reader.bits_read() < Self::MAX_BITS
+            let rest_start = reader.bits_read();
+            let required_bits = <#inner_ty as ::abstract_bits::AbstractBits>::MIN_BITS + (#reserved_bits);
+
+            while reader.remaining_bits()
+                >= required_bits
+                && (reader.bits_read() - rest_start)
+                    + <#inner_ty as ::abstract_bits::AbstractBits>::MIN_BITS <= #window
             {
                 let element =
                     <#inner_ty as ::abstract_bits::AbstractBits>::read_abstract_bits(reader)
@@ -62,7 +79,7 @@ pub(crate) fn min_bits() -> TokenStream {
     quote! { 0 }
 }
 
-pub(crate) fn max_bits(max_bytes: usize) -> TokenStream {
-    let bits = Literal::usize_unsuffixed(max_bytes * 8);
+pub(crate) fn max_bits(max_bits: usize) -> TokenStream {
+    let bits = Literal::usize_unsuffixed(max_bits);
     quote! { #bits }
 }

--- a/abstract-bits-derive/src/codegen/fields/rest_list.rs
+++ b/abstract-bits-derive/src/codegen/fields/rest_list.rs
@@ -28,6 +28,7 @@ pub(crate) fn read(
     struct_name: &Literal,
     max_bits: usize,
     following_min_bits: &[TokenStream],
+    following_max_bits: &[TokenStream],
 ) -> TokenStream {
     let field_name = Literal::string(&inner_type.ident.to_string());
     let field_ident = &inner_type.ident;
@@ -36,12 +37,32 @@ pub(crate) fn read(
     // Bits the fields after us still need
     let reserved_bits = quote! { 0 #(+ (#following_min_bits))* };
 
+    // Reserving the right number of bits is only correct when every following field has
+    // a fixed size. A following field with `MIN_BITS != MAX_BITS` is variable-size
+    // (a length-prefixed list, an Option, another rest field, or a struct containing
+    // any of these), which we reject here at compile time.
+    let fixed_size_assertions: Vec<_> = following_min_bits
+        .iter()
+        .zip(following_max_bits)
+        .map(|(min, max)| {
+            quote! {
+                const {
+                    assert!(
+                        (#min) == (#max),
+                        "a rest field can only be followed by fixed-size fields"
+                    );
+                }
+            }
+        })
+        .collect();
+
     // Arbitrary integer fields are stored in a vec of _primitive_ integers
     if let Some(bits) = inner_type.bits {
         let utype = arbitrary_uint(bits, field_ident.span());
         let element_bits = Literal::usize_unsuffixed(bits as usize);
 
         quote_spanned! {field_ident.span()=>
+            #(#fixed_size_assertions)*
             let mut #field_ident = ::std::vec::Vec::new();
             let rest_start = reader.bits_read();
             while reader.remaining_bits() >= #element_bits + (#reserved_bits)
@@ -57,6 +78,7 @@ pub(crate) fn read(
         let inner_ty = generics_to_fully_qualified(inner_type.out_ty.clone());
 
         quote_spanned! {inner_ty.span()=>
+            #(#fixed_size_assertions)*
             let mut #field_ident = ::std::vec::Vec::new();
             let rest_start = reader.bits_read();
             let required_bits = <#inner_ty as ::abstract_bits::AbstractBits>::MIN_BITS + (#reserved_bits);

--- a/abstract-bits-derive/src/codegen/fields/rest_list.rs
+++ b/abstract-bits-derive/src/codegen/fields/rest_list.rs
@@ -20,7 +20,7 @@ pub(crate) fn read(inner_type: &NormalField, struct_name: &Literal) -> TokenStre
     let inner_ty = generics_to_fully_qualified(inner_type.out_ty.clone());
     quote_spanned! {inner_ty.span()=>
         let mut #field_ident = ::std::vec::Vec::new();
-        while reader.remaining_bits() > 0 {
+        while reader.remaining_bits() > 0 && reader.bits_read() < Self::MAX_BITS {
             let element =
                 <#inner_ty as ::abstract_bits::AbstractBits>::read_abstract_bits(reader)
                     .map_err(|cause| cause.read_field(#struct_name, #field_name))?;

--- a/abstract-bits-derive/src/codegen/fields/rest_list.rs
+++ b/abstract-bits-derive/src/codegen/fields/rest_list.rs
@@ -2,14 +2,23 @@ use proc_macro2::{Literal, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 
-use crate::codegen::generics_to_fully_qualified;
+use crate::codegen::{arbitrary_uint, generics_to_fully_qualified};
 use crate::model::NormalField;
 
 pub(crate) fn write(inner_type: &NormalField) -> TokenStream {
     let field_ident = &inner_type.ident;
-    quote_spanned! {field_ident.span()=>
-        for element in &self.#field_ident {
-            ::abstract_bits::AbstractBits::write_abstract_bits(element, writer)?;
+    if let Some(bits) = inner_type.bits {
+        let utype = arbitrary_uint(bits, field_ident.span());
+        quote_spanned! {field_ident.span()=>
+            for element in &self.#field_ident {
+                #utype::new(*element).write_abstract_bits(writer)?;
+            }
+        }
+    } else {
+        quote_spanned! {field_ident.span()=>
+            for element in &self.#field_ident {
+                ::abstract_bits::AbstractBits::write_abstract_bits(element, writer)?;
+            }
         }
     }
 }
@@ -17,14 +26,34 @@ pub(crate) fn write(inner_type: &NormalField) -> TokenStream {
 pub(crate) fn read(inner_type: &NormalField, struct_name: &Literal) -> TokenStream {
     let field_name = Literal::string(&inner_type.ident.to_string());
     let field_ident = &inner_type.ident;
-    let inner_ty = generics_to_fully_qualified(inner_type.out_ty.clone());
-    quote_spanned! {inner_ty.span()=>
-        let mut #field_ident = ::std::vec::Vec::new();
-        while reader.remaining_bits() > 0 && reader.bits_read() < Self::MAX_BITS {
-            let element =
-                <#inner_ty as ::abstract_bits::AbstractBits>::read_abstract_bits(reader)
-                    .map_err(|cause| cause.read_field(#struct_name, #field_name))?;
-            #field_ident.push(element);
+
+    // Arbitrary integer fields are stored in a vec of _primitive_ integers
+    if let Some(bits) = inner_type.bits {
+        let utype = arbitrary_uint(bits, field_ident.span());
+        let element_bits = Literal::usize_unsuffixed(bits as usize);
+
+        quote_spanned! {field_ident.span()=>
+            let mut #field_ident = ::std::vec::Vec::new();
+            while reader.remaining_bits() >= #element_bits && reader.bits_read() < Self::MAX_BITS {
+                let element = #utype::read_abstract_bits(reader)
+                    .map_err(|cause| cause.read_field(#struct_name, #field_name))?
+                    .value();
+                #field_ident.push(element);
+            }
+        }
+    } else {
+        let inner_ty = generics_to_fully_qualified(inner_type.out_ty.clone());
+
+        quote_spanned! {inner_ty.span()=>
+            let mut #field_ident = ::std::vec::Vec::new();
+            while reader.remaining_bits() >= <#inner_ty as ::abstract_bits::AbstractBits>::MIN_BITS
+                && reader.bits_read() < Self::MAX_BITS
+            {
+                let element =
+                    <#inner_ty as ::abstract_bits::AbstractBits>::read_abstract_bits(reader)
+                        .map_err(|cause| cause.read_field(#struct_name, #field_name))?;
+                #field_ident.push(element);
+            }
         }
     }
 }

--- a/abstract-bits-derive/src/model.rs
+++ b/abstract-bits-derive/src/model.rs
@@ -350,8 +350,7 @@ fn field_attr(field: &syn::Field) -> FieldAttr {
         } else if meta.path.is_ident("rest") {
             parsed.rest = true;
         } else if meta.path.is_ident("max_bits") {
-            parsed.max_bits =
-                Some(meta.value()?.parse::<syn::LitInt>()?.base10_parse()?);
+            parsed.max_bits = Some(meta.value()?.parse::<syn::LitInt>()?.base10_parse()?);
         } else {
             return Err(meta.error("unknown abstract_bits attribute"));
         }

--- a/abstract-bits-derive/src/model.rs
+++ b/abstract-bits-derive/src/model.rs
@@ -85,6 +85,11 @@ pub enum Field {
         max_len: usize,
         controller: syn::Expr,
     },
+    RestList {
+        full_type: NormalField,
+        inner_type: NormalField,
+        max_bytes: usize,
+    },
     Array {
         length: syn::Expr,
         inner_type: syn::Type,
@@ -106,6 +111,9 @@ impl Field {
                 full_type: field, ..
             }
             | Field::List {
+                full_type: field, ..
+            }
+            | Field::RestList {
                 full_type: field, ..
             } => {
                 let mut filtered_field = field.clone();
@@ -157,12 +165,13 @@ impl Field {
             .ident
             .as_ref()
             .expect("unit structs are not tranformed into model::Field");
+        let attr = field_attr(&field);
         if ident == "reserved" {
             let padding = padding_from_type(&field.ty)
                 .unwrap_or_else(|(msg, span)| abort!(span, msg));
             Self::PaddBits(padding)
         } else if let Some(option_stripped) = strip_option(field.clone()) {
-            let controller = presence_from_attr(&field).unwrap_or_else(|| {
+            let controller = attr.presence_from.unwrap_or_else(|| {
                 abort!(
                     ident.span(),
                     "Option field '{}' requires presence_from attribute",
@@ -175,19 +184,34 @@ impl Field {
                 controller,
             }
         } else if let Some(vec_stripped) = strip_vec(field.clone()) {
-            let controller = length_from_attr(&field).unwrap_or_else(|| {
+            if let Some(controller) = attr.length_from {
+                let max_len =
+                    max_size_from_controller_field(&controller, previous_fields);
+                Self::List {
+                    inner_type: NormalField::from(vec_stripped),
+                    max_len,
+                    full_type: NormalField::from(field),
+                    controller,
+                }
+            } else if attr.rest {
+                let max_bytes = attr.max_bytes.unwrap_or_else(|| {
+                    abort!(
+                        ident.span(),
+                        "rest field '{}' requires a max_bytes bound",
+                        ident
+                    )
+                });
+                Self::RestList {
+                    inner_type: NormalField::from(vec_stripped),
+                    full_type: NormalField::from(field),
+                    max_bytes,
+                }
+            } else {
                 abort!(
                     ident.span(),
-                    "List field '{}' requires length_from attribute",
+                    "List field '{}' requires a length_from or rest attribute",
                     ident
                 )
-            });
-            let max_len = max_size_from_controller_field(&controller, previous_fields);
-            Self::List {
-                inner_type: NormalField::from(vec_stripped),
-                max_len,
-                full_type: NormalField::from(field),
-                controller,
             }
         } else if let syn::Type::Array(a) = &field.ty {
             Self::Array {
@@ -293,68 +317,40 @@ fn strip_generic(field: syn::Field, outer_ident: &str) -> Option<syn::Field> {
     Some(new_field)
 }
 
-fn length_from_attr(field: &syn::Field) -> Option<syn::Expr> {
-    fn parse(attr: &Attribute) -> Option<Result<syn::Expr, ()>> {
-        let Ok(list) = attr.meta.require_list() else {
-            return Some(Err(()));
-        };
-        let mut tokens = list.tokens.clone().into_iter();
-        match tokens.next() {
-            Some(TokenTree::Ident(ident)) if ident == "length_from" => (),
-            _ => return None,
-        }
-        match tokens.next() {
-            Some(TokenTree::Punct(punct)) if punct.as_char() == '=' => (),
-            _ => return Some(Err(())),
-        }
-
-        // Parse remaining tokens as expression
-        Some(syn::parse2::<syn::Expr>(tokens.collect()).map_err(|_| ()))
-    }
-
-    let attr = field
-        .attrs
-        .iter()
-        .find(|a| a.path().is_ident("abstract_bits"))?;
-
-    match parse(attr)? {
-        Ok(expr) => Some(expr),
-        Err(_) => abort!(attr.span(), "invalid abstract_bits attribute"; 
-            help = "The syntax is: #[abstract_bits(length_from = <expr>)] with expr \
-            an expression controlling this vec's length"),
-    }
+#[derive(Default)]
+struct FieldAttr {
+    length_from: Option<syn::Expr>,
+    presence_from: Option<syn::Expr>,
+    rest: bool,
+    max_bytes: Option<usize>,
 }
 
-fn presence_from_attr(field: &syn::Field) -> Option<syn::Expr> {
-    fn parse(attr: &Attribute) -> Option<Result<syn::Expr, ()>> {
-        let Ok(list) = attr.meta.require_list() else {
-            return Some(Err(()));
-        };
-        let mut tokens = list.tokens.clone().into_iter();
-        match tokens.next() {
-            Some(TokenTree::Ident(ident)) if ident == "presence_from" => (),
-            _ => return None,
-        }
-        match tokens.next() {
-            Some(TokenTree::Punct(punct)) if punct.as_char() == '=' => (),
-            _ => return Some(Err(())),
-        }
-
-        // Parse remaining tokens as expression
-        Some(syn::parse2::<syn::Expr>(tokens.collect()).map_err(|_| ()))
-    }
-
-    let attr = field
+fn field_attr(field: &syn::Field) -> FieldAttr {
+    let mut parsed = FieldAttr::default();
+    let Some(attr) = field
         .attrs
         .iter()
-        .find(|a| a.path().is_ident("abstract_bits"))?;
-
-    match parse(attr)? {
-        Ok(expr) => Some(expr),
-        Err(_) => abort!(attr.span(), "invalid abstract_bits attribute"; 
-            help = "The syntax is: #[abstract_bits(presence_from = <expr>)] where the \
-            boolean expr controls this option's presence"),
-    }
+        .find(|a| a.path().is_ident("abstract_bits"))
+    else {
+        return parsed;
+    };
+    attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("length_from") {
+            parsed.length_from = Some(meta.value()?.parse()?);
+        } else if meta.path.is_ident("presence_from") {
+            parsed.presence_from = Some(meta.value()?.parse()?);
+        } else if meta.path.is_ident("rest") {
+            parsed.rest = true;
+        } else if meta.path.is_ident("max_bytes") {
+            parsed.max_bytes =
+                Some(meta.value()?.parse::<syn::LitInt>()?.base10_parse()?);
+        } else {
+            return Err(meta.error("unknown abstract_bits attribute"));
+        }
+        Ok(())
+    })
+    .unwrap_or_else(|e| abort!(attr.span(), "invalid abstract_bits attribute: {}", e));
+    parsed
 }
 
 impl Model {
@@ -371,13 +367,13 @@ impl Model {
     }
 
     pub(crate) fn from_enum(item: syn::ItemEnum, attr: TokenStream) -> Self {
+        Self::reject_item_generics(&item.generics);
+        let repr = require_repr_attr(&item.attrs, item.span());
+
         let Ok(bits) = get_num_bits(attr) else {
             abort!(item.span(), "Every enum must be attributed with its serialized size \
                 in bits."; note = "Example: #[abstract_bits::abstract_bits(bits=2)]");
         };
-        Self::reject_item_generics(&item.generics);
-
-        let repr = require_repr_attr(&item.attrs, item.span());
         let variants: Vec<_> = item
             .variants
             .clone()
@@ -512,22 +508,18 @@ fn verify_all_discriminants_fit(variants: &[EmptyVariant], bits: usize) {
 }
 
 fn get_num_bits(attr: TokenStream) -> Result<usize, ()> {
-    let mut tokens = attr.into_iter();
-    match tokens.next() {
-        Some(TokenTree::Ident(item)) if item == "bits" => (),
-        _ => return Err(()),
+    let meta: syn::MetaNameValue = syn::parse2(attr).map_err(|_| ())?;
+    if !meta.path.is_ident("bits") {
+        return Err(());
     }
-
-    match tokens.next() {
-        Some(TokenTree::Punct(punct)) if punct.as_char() == '=' => (),
-        _ => return Err(()),
-    }
-
-    let Some(TokenTree::Literal(num)) = tokens.next() else {
+    let syn::Expr::Lit(syn::ExprLit {
+        lit: syn::Lit::Int(num),
+        ..
+    }) = meta.value
+    else {
         return Err(());
     };
-
-    num.to_string().parse().map_err(|_| ())
+    num.base10_parse().map_err(|_| ())
 }
 
 fn require_repr_attr(attrs: &[Attribute], span: Span) -> Ident {

--- a/abstract-bits-derive/src/model.rs
+++ b/abstract-bits-derive/src/model.rs
@@ -201,9 +201,17 @@ impl Field {
                         ident
                     )
                 });
+                let inner_type = NormalField::from(vec_stripped);
+                let mut full_type = NormalField::from(field);
+                if inner_type.bits.is_some() {
+                    let inner_out_ty = &inner_type.out_ty;
+                    full_type.out_ty = parse_quote_spanned!(
+                        inner_out_ty.span()=> Vec<#inner_out_ty>
+                    );
+                }
                 Self::RestList {
-                    inner_type: NormalField::from(vec_stripped),
-                    full_type: NormalField::from(field),
+                    inner_type,
+                    full_type,
                     max_bytes,
                 }
             } else {

--- a/abstract-bits-derive/src/model.rs
+++ b/abstract-bits-derive/src/model.rs
@@ -88,7 +88,7 @@ pub enum Field {
     RestList {
         full_type: NormalField,
         inner_type: NormalField,
-        max_bytes: usize,
+        max_bits: usize,
     },
     Array {
         length: syn::Expr,
@@ -194,10 +194,10 @@ impl Field {
                     controller,
                 }
             } else if attr.rest {
-                let max_bytes = attr.max_bytes.unwrap_or_else(|| {
+                let max_bits = attr.max_bits.unwrap_or_else(|| {
                     abort!(
                         ident.span(),
-                        "rest field '{}' requires a max_bytes bound",
+                        "rest field '{}' requires a max_bits bound",
                         ident
                     )
                 });
@@ -212,7 +212,7 @@ impl Field {
                 Self::RestList {
                     inner_type,
                     full_type,
-                    max_bytes,
+                    max_bits,
                 }
             } else {
                 abort!(
@@ -330,7 +330,7 @@ struct FieldAttr {
     length_from: Option<syn::Expr>,
     presence_from: Option<syn::Expr>,
     rest: bool,
-    max_bytes: Option<usize>,
+    max_bits: Option<usize>,
 }
 
 fn field_attr(field: &syn::Field) -> FieldAttr {
@@ -349,8 +349,8 @@ fn field_attr(field: &syn::Field) -> FieldAttr {
             parsed.presence_from = Some(meta.value()?.parse()?);
         } else if meta.path.is_ident("rest") {
             parsed.rest = true;
-        } else if meta.path.is_ident("max_bytes") {
-            parsed.max_bytes =
+        } else if meta.path.is_ident("max_bits") {
+            parsed.max_bits =
                 Some(meta.value()?.parse::<syn::LitInt>()?.base10_parse()?);
         } else {
             return Err(meta.error("unknown abstract_bits attribute"));
@@ -438,6 +438,7 @@ impl Model {
                 fields.push(field);
             }
             hide_same_struct_controllers(&mut fields);
+            reject_unsupported_rest_layout(&fields);
             Type::NormalStruct(fields)
         };
 
@@ -446,6 +447,32 @@ impl Model {
             vis: item.vis,
             ident: item.ident,
             ty,
+        }
+    }
+}
+
+// The only fields that can follow a `rest` field are fixed size: otherwise, parsing
+// becomes ambiguous.
+fn reject_unsupported_rest_layout(fields: &[Field]) {
+    for (i, field) in fields.iter().enumerate() {
+        let Field::RestList { full_type, .. } = field else {
+            continue;
+        };
+        for following in &fields[i + 1..] {
+            let kind = match following {
+                Field::List { .. } => "a length-prefixed list",
+                Field::Option { .. } => "an Option",
+                Field::RestList { .. } => "another rest field",
+                _ => continue,
+            };
+
+            abort!(
+                full_type.ident.span(),
+                "rest field '{}' cannot be followed by {}",
+                full_type.ident,
+                kind;
+                help = "a rest field can only be followed by fixed-size fields"
+            );
         }
     }
 }

--- a/abstract-bits-derive/src/model.rs
+++ b/abstract-bits-derive/src/model.rs
@@ -437,7 +437,6 @@ impl Model {
                 fields.push(field);
             }
             hide_same_struct_controllers(&mut fields);
-            reject_unsupported_rest_layout(&fields);
             Type::NormalStruct(fields)
         };
 
@@ -446,32 +445,6 @@ impl Model {
             vis: item.vis,
             ident: item.ident,
             ty,
-        }
-    }
-}
-
-// The only fields that can follow a `rest` field are fixed size: otherwise, parsing
-// becomes ambiguous.
-fn reject_unsupported_rest_layout(fields: &[Field]) {
-    for (i, field) in fields.iter().enumerate() {
-        let Field::RestList { full_type, .. } = field else {
-            continue;
-        };
-        for following in &fields[i + 1..] {
-            let kind = match following {
-                Field::List { .. } => "a length-prefixed list",
-                Field::Option { .. } => "an Option",
-                Field::RestList { .. } => "another rest field",
-                _ => continue,
-            };
-
-            abort!(
-                full_type.ident.span(),
-                "rest field '{}' cannot be followed by {}",
-                full_type.ident,
-                kind;
-                help = "a rest field can only be followed by fixed-size fields"
-            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,12 @@ impl BitReader<'_> {
     read_primitive! {read_u64, u64}
 }
 
+impl BitReader<'_> {
+    pub fn remaining_bits(&self) -> usize {
+        self.buf.len() - self.pos
+    }
+}
+
 impl<'a> From<&'a [u8]> for BitReader<'a> {
     fn from(bytes: &'a [u8]) -> Self {
         Self {

--- a/tests/bit_and_byte_api.rs
+++ b/tests/bit_and_byte_api.rs
@@ -10,21 +10,32 @@ struct SubByte {
 
 #[test]
 fn bits_buffer_has_exact_length() {
-    let bits = SubByte { head: 0xAB, tail: 5 }.to_abstract_bits().unwrap();
+    let bits = SubByte {
+        head: 0xAB,
+        tail: 5,
+    }
+    .to_abstract_bits()
+    .unwrap();
     assert_eq!(bits.len(), 11);
     assert_eq!(bits.len(), SubByte::MAX_BITS);
 }
 
 #[test]
 fn roundtrips_through_bits() {
-    let value = SubByte { head: 0xAB, tail: 5 };
+    let value = SubByte {
+        head: 0xAB,
+        tail: 5,
+    };
     let bits = value.to_abstract_bits().unwrap();
     assert_eq!(SubByte::from_abstract_bits(&bits).unwrap(), value);
 }
 
 #[test]
 fn roundtrips_through_bytes_with_tail_padding() {
-    let value = SubByte { head: 0xAB, tail: 5 };
+    let value = SubByte {
+        head: 0xAB,
+        tail: 5,
+    };
     let bytes = value.to_abstract_bytes().unwrap();
     assert_eq!(bytes.len(), 2); // 11 bits padded up to 2 whole bytes
     assert_eq!(SubByte::from_abstract_bytes(&bytes).unwrap(), value);
@@ -32,7 +43,10 @@ fn roundtrips_through_bytes_with_tail_padding() {
 
 #[test]
 fn bytes_are_the_bit_buffer_padded_to_a_byte() {
-    let value = SubByte { head: 0xAB, tail: 5 };
+    let value = SubByte {
+        head: 0xAB,
+        tail: 5,
+    };
     let bits = value.to_abstract_bits().unwrap();
     assert_eq!(value.to_abstract_bytes().unwrap(), bits.into_vec());
 }

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -7,7 +7,7 @@ use hex_literal::hex;
 struct Frame {
     field1: u8,
     field2: u16,
-    #[abstract_bits(rest, max_bytes = 16)]
+    #[abstract_bits(rest, max_bits = 128)]
     rest: Vec<u8>,
 }
 
@@ -16,7 +16,7 @@ struct Frame {
 struct LargerFrame {
     field1: u8,
     field2: u16,
-    #[abstract_bits(rest, max_bytes = 16)]
+    #[abstract_bits(rest, max_bits = 128)]
     rest: Vec<u16>,
 }
 
@@ -76,7 +76,7 @@ fn rest_max_length() {
 #[derive(Debug, PartialEq)]
 struct UnalignedFrame {
     header: u8,
-    #[abstract_bits(rest, max_bytes = 16)]
+    #[abstract_bits(rest, max_bits = 128)]
     rest: Vec<u7>,
 }
 
@@ -101,7 +101,7 @@ struct Triplet {
 #[derive(Debug, PartialEq)]
 struct StructRestFrame {
     header: u8,
-    #[abstract_bits(rest, max_bytes = 16)]
+    #[abstract_bits(rest, max_bits = 128)]
     rest: Vec<Triplet>,
 }
 

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -143,7 +143,10 @@ fn rest_max_length_unaligned() {
         }
     );
 
-    assert_eq!(frame.to_abstract_bytes().unwrap(), &bytes[0..bytes.len() - 1]);
+    assert_eq!(
+        frame.to_abstract_bytes().unwrap(),
+        &bytes[0..bytes.len() - 1]
+    );
 }
 
 #[abstract_bits]

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -23,7 +23,7 @@ struct LargerFrame {
 #[test]
 fn rest_captures_trailing_bytes() {
     let bytes = hex!("aa ccbb 01 02 03").to_vec();
-    let frame = Frame::from_abstract_bits(&bytes).unwrap();
+    let frame = Frame::from_abstract_bytes(&bytes).unwrap();
 
     assert_eq!(
         frame,
@@ -33,7 +33,7 @@ fn rest_captures_trailing_bytes() {
             rest: vec![0x01, 0x02, 0x03],
         }
     );
-    assert_eq!(frame.to_abstract_bits().unwrap(), bytes);
+    assert_eq!(frame.to_abstract_bytes().unwrap(), bytes);
 }
 
 #[test]
@@ -43,10 +43,10 @@ fn rest_can_be_empty() {
         field2: 0x0002,
         rest: vec![],
     };
-    let bytes = frame.to_abstract_bits().unwrap();
+    let bytes = frame.to_abstract_bytes().unwrap();
 
     assert_eq!(bytes, hex!("01 0200").to_vec());
-    assert_eq!(Frame::from_abstract_bits(&bytes).unwrap(), frame);
+    assert_eq!(Frame::from_abstract_bytes(&bytes).unwrap(), frame);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn rest_max_length() {
     )
     .to_vec();
 
-    let frame = Frame::from_abstract_bits(&bytes).unwrap();
+    let frame = Frame::from_abstract_bytes(&bytes).unwrap();
     assert_eq!(
         frame,
         Frame {
@@ -86,8 +86,8 @@ fn rest_unaligned_prefix_roundtrips() {
         header: 0xAA,
         rest: vec![1, 2, 3, 4, 5],
     };
-    let bytes = frame.to_abstract_bits().unwrap();
-    assert_eq!(UnalignedFrame::from_abstract_bits(&bytes).unwrap(), frame);
+    let bits = frame.to_abstract_bits().unwrap();
+    assert_eq!(UnalignedFrame::from_abstract_bits(&bits).unwrap(), frame);
 }
 
 #[abstract_bits]
@@ -115,8 +115,8 @@ fn rest_unaligned_struct_roundtrips() {
             Triplet { a: 3, b: true },
         ],
     };
-    let bytes = frame.to_abstract_bits().unwrap();
-    assert_eq!(StructRestFrame::from_abstract_bits(&bytes).unwrap(), frame);
+    let bits = frame.to_abstract_bits().unwrap();
+    assert_eq!(StructRestFrame::from_abstract_bits(&bits).unwrap(), frame);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn rest_max_length_unaligned() {
     )
     .to_vec();
 
-    let frame = LargerFrame::from_abstract_bits(&bytes).unwrap();
+    let frame = LargerFrame::from_abstract_bytes(&bytes).unwrap();
     assert_eq!(
         frame,
         LargerFrame {
@@ -142,4 +142,6 @@ fn rest_max_length_unaligned() {
             ],
         }
     );
+
+    assert_eq!(frame.to_abstract_bytes().unwrap(), &bytes[0..bytes.len() - 1]);
 }

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -145,3 +145,58 @@ fn rest_max_length_unaligned() {
 
     assert_eq!(frame.to_abstract_bytes().unwrap(), &bytes[0..bytes.len() - 1]);
 }
+
+#[abstract_bits]
+#[derive(Debug, PartialEq)]
+struct TrailingField {
+    header: u8,
+    #[abstract_bits(rest, max_bits = 128)]
+    rest: Vec<u32>,
+    // Room is reserved for `trailing`
+    trailing: u16,
+}
+
+#[test]
+fn rest_trailing_field() {
+    let bytes = hex!(
+        "
+        00
+        44 33 22 11
+        dd cc bb aa
+        ff ee
+        "
+    );
+
+    let frame = TrailingField::from_abstract_bytes(&bytes).unwrap();
+    assert_eq!(
+        frame,
+        TrailingField {
+            header: 0x00,
+            rest: vec![0x11223344, 0xaabbccdd],
+            trailing: 0xeeff,
+        }
+    );
+}
+
+#[test]
+fn rest_trailing_field_no_space() {
+    let bytes = hex!(
+        "
+        00
+        44 33 22 11
+        dd cc bb aa
+        ff
+        "
+    );
+
+    let frame = TrailingField::from_abstract_bytes(&bytes).unwrap();
+    assert_eq!(
+        frame,
+        TrailingField {
+            header: 0x00,
+            rest: vec![0x11223344],
+            trailing: 0xccdd,
+            // `bb aa ff` are not consumed
+        }
+    );
+}

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -72,7 +72,6 @@ fn rest_max_length() {
     );
 }
 
-
 #[abstract_bits]
 #[derive(Debug, PartialEq)]
 struct UnalignedFrame {

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -11,6 +11,15 @@ struct Frame {
     rest: Vec<u8>,
 }
 
+#[abstract_bits]
+#[derive(Debug, PartialEq)]
+struct LargerFrame {
+    field1: u8,
+    field2: u16,
+    #[abstract_bits(rest, max_bytes = 16)]
+    rest: Vec<u16>,
+}
+
 #[test]
 fn rest_captures_trailing_bytes() {
     let bytes = hex!("aa ccbb 01 02 03").to_vec();
@@ -38,4 +47,100 @@ fn rest_can_be_empty() {
 
     assert_eq!(bytes, hex!("01 0200").to_vec());
     assert_eq!(Frame::from_abstract_bits(&bytes).unwrap(), frame);
+}
+
+#[test]
+fn rest_max_length() {
+    let bytes = hex!(
+        "
+        00
+        11 22
+        33 44 55 66 77 88 99 aa bb cc dd ee ff 01 02 03
+        04 05 06 07 08 09
+    "
+    )
+    .to_vec();
+
+    let frame = Frame::from_abstract_bits(&bytes).unwrap();
+    assert_eq!(
+        frame,
+        Frame {
+            field1: 0x00,
+            field2: 0x2211,
+            rest: hex!("33 44 55 66 77 88 99 aa bb cc dd ee ff 01 02 03").to_vec(),
+        }
+    );
+}
+
+
+#[abstract_bits]
+#[derive(Debug, PartialEq)]
+struct UnalignedFrame {
+    header: u8,
+    #[abstract_bits(rest, max_bytes = 16)]
+    rest: Vec<u7>,
+}
+
+#[test]
+fn rest_unaligned_prefix_roundtrips() {
+    let frame = UnalignedFrame {
+        header: 0xAA,
+        rest: vec![1, 2, 3, 4, 5],
+    };
+    let bytes = frame.to_abstract_bits().unwrap();
+    assert_eq!(UnalignedFrame::from_abstract_bits(&bytes).unwrap(), frame);
+}
+
+#[abstract_bits]
+#[derive(Debug, PartialEq, Clone)]
+struct Triplet {
+    a: u4,
+    b: bool,
+}
+
+#[abstract_bits]
+#[derive(Debug, PartialEq)]
+struct StructRestFrame {
+    header: u8,
+    #[abstract_bits(rest, max_bytes = 16)]
+    rest: Vec<Triplet>,
+}
+
+#[test]
+fn rest_unaligned_struct_roundtrips() {
+    let frame = StructRestFrame {
+        header: 0xAA,
+        rest: vec![
+            Triplet { a: 1, b: true },
+            Triplet { a: 2, b: false },
+            Triplet { a: 3, b: true },
+        ],
+    };
+    let bytes = frame.to_abstract_bits().unwrap();
+    assert_eq!(StructRestFrame::from_abstract_bits(&bytes).unwrap(), frame);
+}
+
+#[test]
+fn rest_max_length_unaligned() {
+    let bytes = hex!(
+        "
+        00
+        11 22
+        33 44 55 66 77 88 99 aa bb cc dd ee ff 01 02 03
+        04
+    "
+    )
+    .to_vec();
+
+    let frame = LargerFrame::from_abstract_bits(&bytes).unwrap();
+    assert_eq!(
+        frame,
+        LargerFrame {
+            field1: 0x00,
+            field2: 0x2211,
+            rest: vec![
+                0x4433, 0x6655, 0x8877, 0xaa99, 0xccbb, 0xeedd, 0x01ff, 0x0302,
+            ],
+        }
+    );
 }

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -1,0 +1,41 @@
+//! The `rest` field mode: read a Vec until the reader is exhausted
+use abstract_bits::{AbstractBits, abstract_bits};
+use hex_literal::hex;
+
+#[abstract_bits]
+#[derive(Debug, PartialEq)]
+struct Frame {
+    field1: u8,
+    field2: u16,
+    #[abstract_bits(rest, max_bytes = 16)]
+    rest: Vec<u8>,
+}
+
+#[test]
+fn rest_captures_trailing_bytes() {
+    let bytes = hex!("aa ccbb 01 02 03").to_vec();
+    let frame = Frame::from_abstract_bits(&bytes).unwrap();
+
+    assert_eq!(
+        frame,
+        Frame {
+            field1: 0xAA,
+            field2: 0xBBCC,
+            rest: vec![0x01, 0x02, 0x03],
+        }
+    );
+    assert_eq!(frame.to_abstract_bits().unwrap(), bytes);
+}
+
+#[test]
+fn rest_can_be_empty() {
+    let frame = Frame {
+        field1: 0x01,
+        field2: 0x0002,
+        rest: vec![],
+    };
+    let bytes = frame.to_abstract_bits().unwrap();
+
+    assert_eq!(bytes, hex!("01 0200").to_vec());
+    assert_eq!(Frame::from_abstract_bits(&bytes).unwrap(), frame);
+}


### PR DESCRIPTION
This PR adds support for `#[abstract_bits(rest, max_bits = N)]`, a way to specify vectors of trailing data for a struct. The primary use case for me will be TLV support (a future PR).

One fun edge case is the ability to parse trailing data that is shorter than a single "rest" field's element:

```rust
#[abstract_bits]
#[derive(Debug, PartialEq)]
struct TrailingField {
    header: u8,
    #[abstract_bits(rest, max_bits = 128)]
    rest: Vec<u32>,
    trailing: u16,  // you can parse data after a `rest` field
}
```

I've added a compile-time check to ensure fields that come after `rest` are all statically sized, since supporting dynamically-sized fields would complicate size computations and also seem like something that wouldn't really occur in practice.